### PR TITLE
Fix erroneous ListBox prefix

### DIFF
--- a/WPF-conventions.md
+++ b/WPF-conventions.md
@@ -6,7 +6,7 @@
 | ComboBox                | **cmb** | 
 | Grid                    | **grd** | 
 | Label                   | **lbl** |
-| ListBox                 | **lbl** |
+| ListBox                 | **lst** |
 | ProgressBar             | **pgb** |
 | RadioButton             | **rdb** |
 | Slider                  | **sld** |


### PR DESCRIPTION
ListBox had the `lbl` prefix, which is double. Proposing `lst`.